### PR TITLE
Add zeitwerk and thor dependencies

### DIFF
--- a/lib/llm_mcp.rb
+++ b/lib/llm_mcp.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
-require_relative "llm_mcp/version"
+require "zeitwerk"
+
+loader = Zeitwerk::Loader.for_gem
+loader.setup
 
 module LlmMcp
   class Error < StandardError; end
   # Your code goes here...
 end
+
+loader.eager_load

--- a/llm-mcp.gemspec
+++ b/llm-mcp.gemspec
@@ -32,8 +32,9 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  # Dependencies
+  spec.add_dependency "zeitwerk", "~> 2.7.3"
+  spec.add_dependency "thor", "~> 1.3"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
## Summary
- Added zeitwerk (~> 2.7.3) and thor (~> 1.3) as gem dependencies
- Configured Zeitwerk autoloading following best practices
- Removed manual require_relative statements in favor of autoloading

## Changes
1. Updated `llm-mcp.gemspec` to include zeitwerk and thor dependencies
2. Set up Zeitwerk loader in `lib/llm_mcp.rb`:
   - Used `Zeitwerk::Loader.for_gem` for proper gem configuration
   - Added `loader.setup` before module definition
   - Added `loader.eager_load` for production readiness

## Test plan
- [x] Verified gem installs successfully with `bundle install`
- [x] Tested autoloading works correctly (constants are properly loaded)
- [x] Confirmed VERSION constant is accessible

🤖 Generated with [Claude Code](https://claude.ai/code)