### PR TITLE
Add LLM and MCP gem dependencies

### DIFF
--- a/llm-mcp.gemspec
+++ b/llm-mcp.gemspec
@@ -35,6 +35,9 @@ Gem::Specification.new do |spec|
   # Dependencies
   spec.add_dependency "zeitwerk", "~> 2.7.3"
   spec.add_dependency "thor", "~> 1.3"
+  spec.add_dependency "ruby_llm"
+  spec.add_dependency "ruby_llm-mcp"
+  spec.add_dependency "fast-mcp-annotations"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
## Summary
- Added ruby_llm gem for core LLM integration capabilities
- Added ruby_llm-mcp gem for MCP protocol implementation
- Added fast-mcp-annotations gem for MCP tool annotation support

## Test plan
- [x] Run bundle install to verify dependencies resolve correctly
- [ ] Verify gems are compatible with Ruby version requirements
- [ ] Test basic LLM and MCP functionality once integrated

🤖 Generated with [Claude Code](https://claude.ai/code)